### PR TITLE
isUnix: check for "nux" in addition to "nix"

### DIFF
--- a/src/main/java/org/daisy/pipeline/gui/utils/PlatformUtils.java
+++ b/src/main/java/org/daisy/pipeline/gui/utils/PlatformUtils.java
@@ -1,15 +1,17 @@
 package org.daisy.pipeline.gui.utils;
 
 public class PlatformUtils {
+	
+	private static String OS = System.getProperty("os.name").toLowerCase();
 
 	public static boolean isMac() {
-		return System.getProperty("os.name").toLowerCase().contains("mac"); 
+		return OS.contains("mac"); 
 	}
 	public static boolean isWin() {
-		return System.getProperty("os.name").toLowerCase().contains("win");
+		return OS.contains("win");
 	}
 	public static boolean isUnix() {
-		return System.getProperty("os.name").toLowerCase().contains("nix");
+		return OS.contains("nix") || OS.contains("nux") || OS.contains("aix");
 	}
 	public static String getFileBrowserCommand() {
 		if (isMac()) {


### PR DESCRIPTION
Based on http://www.mkyong.com/java/how-to-detect-os-in-java-systemgetpropertyosname/

Should fix the results links part of #34

Works for me on Ubuntu. Tested opening images, XML files and (X)HTML files. (It didn't work for me with chromium but if I changed my default browser to firefox it worked so it must be an issue with how chromium works with xdg-open, maybe it's just my computer.)